### PR TITLE
Better treat non-existing YAML references as parse errors instead of …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ salmonella.log
 yaml.import.scm
 yaml.import.so
 yaml.so
+*~
+*.build.sh
+*.install.sh
+*.link
+*.types

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -170,6 +170,8 @@
     (let* ((h (list (cons "a" "b")))
            (lst (list h h)))
       (test lst (yaml-load "---\n- &1 {a: b}\n- *1\n")))
+    (test '(("x" . "a") ("y" . "a"))
+	  (yaml-load "---\nx: &key a\ny: *key\n"))
     (test (list (cons "foo" "bar")) (yaml-load "--- {'foo':'bar'}"))
     (test (list (list "foo" (cons "bar" "baz")))
           (yaml-load "--- {'foo':{'bar':'baz'}}")))

--- a/yaml.egg
+++ b/yaml.egg
@@ -1,0 +1,14 @@
+;;; yaml.meta -*- Hen -*-
+
+((synopsis "Bindings to libyaml")
+ (author "Aaron Patterson")
+ (license "MIT")
+ (version "0.2.0")
+ (category net)
+ (test-dependencies test)
+ (dependencies sql-null irregex srfi-13 srfi-69)
+ (components
+  (extension
+   yaml
+   (types-file)
+   (link-options "-L" "-lyaml"))))

--- a/yaml.release-info
+++ b/yaml.release-info
@@ -2,6 +2,7 @@
 
 (repo git "git://github.com/tenderlove/chicken-{egg-name}.git")
 (uri targz "https://github.com/tenderlove/chicken-{egg-name}/tarball/v{egg-release}")
+(release "0.2.0")
 (release "0.1.0")
 (release "0.1.1")
 (release "0.1.2")

--- a/yaml.scm
+++ b/yaml.scm
@@ -323,9 +323,7 @@
                         (cons 'document-start seed))
                 (lambda (implicit? seed) (car seed))
                 (lambda (alias seed)
-                  (if (hash-table-exists? anchors alias)
-                      (cons (hash-table-ref anchors alias) seed)
-                      seed))
+		  (cons (hash-table-ref anchors alias) seed))
                 parser-scalar
                 (lambda (anchor tag implicit style seed)
                         (cons (wrap-start-sequence-ctx anchor anchors) seed))

--- a/yaml.scm
+++ b/yaml.scm
@@ -16,8 +16,24 @@
    yaml:scalar-style:folded
   )
 
-(import scheme chicken foreign irregex)
-(use irregex srfi-13 srfi-69 lolevel sql-null posix utils)
+(import scheme)
+
+(cond-expand
+ (chicken-4
+  (import scheme chicken foreign irregex)
+  (use irregex srfi-13 srfi-69 lolevel sql-null posix utils (only extras read-string)))
+ (else
+  (import
+   (chicken base)
+   (chicken type)
+   (chicken foreign)
+   (chicken memory)
+   srfi-12
+   (only (chicken io) read-string)
+   (only (chicken file posix) open-output-file* open-input-file*)
+   (only (chicken process) create-pipe)
+   )
+  (import srfi-13 srfi-69 sql-null (chicken irregex))))
 
 (foreign-declare "#include <yaml.h>")
 
@@ -31,7 +47,7 @@
               (output (open-output-file* out-fd)))
           (yaml-dump-port object output)
           (close-output-port output)
-          (let ((result (read-all input)))
+          (let ((result (read-string #f input)))
             (close-input-port input)
             result)))))
 

--- a/yaml.scm
+++ b/yaml.scm
@@ -267,12 +267,15 @@
         result)
         (loop (cons (cons (cadr stack) (car stack)) the-list) (cddr stack)))))
 
-(define (parser-scalar value anchor tag plain quoted style seed)
+(define ((parser-scalar anchors) value anchor tag plain quoted style seed)
+  (define (record+ value)
+    (if anchor (hash-table-set! anchors anchor value))
+    value)
   (if (equal? "!scheme/symbol" tag)
-      (cons (string->symbol (irregex-replace "^:" value)) seed)
+      (cons (record+ (string->symbol (irregex-replace "^:" value))) seed)
       (if quoted
-          (cons value seed)
-          (cons (parse-scalar value) seed))))
+          (cons (record+ value) seed)
+          (cons (record+ (parse-scalar value)) seed))))
 
 (define possible-string (string->irregex "[^0-9.:+-].*"))
 
@@ -324,7 +327,7 @@
                 (lambda (implicit? seed) (car seed))
                 (lambda (alias seed)
 		  (cons (hash-table-ref anchors alias) seed))
-                parser-scalar
+                (parser-scalar anchors)
                 (lambda (anchor tag implicit style seed)
                         (cons (wrap-start-sequence-ctx anchor anchors) seed))
                 parser-sequence-end


### PR DESCRIPTION
…silently droping them from the sequence.

The existing code runs into strange exceptions.  Try:

(yaml-load "
---
x: &key a
y: *key

")