### PR TITLE
Make tests run under C4/C5

### DIFF
--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,11 +1,14 @@
-(import yaml test srfi-1 sql-null)
-(import (chicken file posix))
-(import (chicken process))
-(import (chicken io))
-(import (chicken condition))
-(import (chicken port))
-
-(define read-all read-string)
+(import scheme)
+(cond-expand
+ (chicken-4
+  (use yaml test srfi-1 sql-null posix))
+ (chicken-5
+  (import yaml test srfi-1 sql-null)
+  (import (chicken file posix))
+  (import (chicken process))
+  (import (chicken io))
+  (import (chicken condition))
+  (import (chicken port))))
 
 (test-begin "yaml")
 


### PR DESCRIPTION
Currently the tests only run on C5 although the egg itself is written to work with both C4 and C5. This PR adjusts the test file similarly. See also #8.