### PR TITLE
Add SRFI-1 to test dependencies for C5

### DIFF
--- a/yaml.egg
+++ b/yaml.egg
@@ -5,7 +5,7 @@
  (license "MIT")
  (version "0.2.0")
  (category net)
- (test-dependencies test)
+ (test-dependencies test srfi-1)
  (dependencies sql-null srfi-13 srfi-69)
  (components
   (extension


### PR DESCRIPTION
After merging this, PR #9 #10 and tagging a new release, #6 could be closed as well.