### PR TITLE
Fix crash when value is a mapping

### DIFF
--- a/yaml.scm
+++ b/yaml.scm
@@ -90,6 +90,11 @@
          (if object
              (scalar emitter "true" #f #f #t #f yaml:scalar-style:any)
              (scalar emitter "false" #f #f #t #f yaml:scalar-style:any)))
+				((pair? object)
+				 (mapping-start emitter #f #f #t yaml:sequence-style:any)
+         (walk-objects (car object) emitter)
+         (walk-objects (cdr object) emitter)
+         (mapping-end emitter))
         (else (abort "unknown"))))
 
 (define (yaml-dump-port object port)


### PR DESCRIPTION
This patch fixes the crash when running this code:

    (yaml-dump (yaml-load " {bar: { baz: quux}}")

There are also some other issues, for example that this:

    (equal? (yaml-load "{bar: [quux]}") (yaml-load "[[bar, quux]]"))

is #t and also that there's no way to create a scheme object that
serialises to an empty yaml sequence [].

One way to solve both issues would be if sequences instead were Scheme
vectors (and mappings stay as alists). That will break older running
code however so I'm not sure how we wanna do it. Maybe it's only me
that's using this egg on C5, and I could port my code over to use
vectors if necessary.
